### PR TITLE
Be more specific when stripping architectures

### DIFF
--- a/Libraries/LPInfra.framework/frameworks-strip.sh
+++ b/Libraries/LPInfra.framework/frameworks-strip.sh
@@ -2,7 +2,7 @@ APP_PATH="${TARGET_BUILD_DIR}/${WRAPPER_NAME}"
 
 # This script loops through the frameworks embedded in the application and
 # removes unused architectures.
-find "$APP_PATH" -name '*.framework' -type d | while read -r FRAMEWORK
+find "$APP_PATH" -name 'LPAMS.framework' -o -name 'LPInfra.framework' -o -name 'LPMessagingSDK.framework' -type d | while read -r FRAMEWORK
 do
 FRAMEWORK_EXECUTABLE_NAME=$(defaults read "$FRAMEWORK/Info.plist" CFBundleExecutable)
 FRAMEWORK_EXECUTABLE_PATH="$FRAMEWORK/$FRAMEWORK_EXECUTABLE_NAME"


### PR DESCRIPTION
An app including its own frameworks that are built alongside the app will produce non-fat binaries, which causes lipo to error. This script shouldn't touch these frameworks.