### PR TITLE
Fix: SampleApp(Objc) crashes with Hardware Keyboard

### DIFF
--- a/Sample Apps/Objective C/SampleApp/MessagingViewController.m
+++ b/Sample Apps/Objective C/SampleApp/MessagingViewController.m
@@ -147,7 +147,6 @@
     }
     
     [self setUserDetails];
-    [[self view] endEditing:YES];
 }
 
 - (IBAction)windowSwitchChanged:(UISwitch *)sender {


### PR DESCRIPTION
### Action:
* remove unnecessary code to avoid crash on showing conversation.